### PR TITLE
Fix too many apps going off screen, Fix top bar going off screen

### DIFF
--- a/svelte-source/src/components/base/Icons.svelte
+++ b/svelte-source/src/components/base/Icons.svelte
@@ -72,8 +72,13 @@
   }
 
   .icons {
-    display: grid;
-    justify-content: left;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: start;
+    align-items: center;
+    flex-direction: column;
+    height: 100%;
+    width: fit-content;
     margin: 10px;
   }
 

--- a/svelte-source/src/components/shared/Apps.svelte
+++ b/svelte-source/src/components/shared/Apps.svelte
@@ -43,9 +43,6 @@
   }
 
   function onMouseMove(e: { movementX: number; movementY: number }) {
-
-
-
     if (moving) {
       if (top + e.movementY < window.innerHeight * 0.05) {
         return

--- a/svelte-source/src/components/shared/Apps.svelte
+++ b/svelte-source/src/components/shared/Apps.svelte
@@ -43,7 +43,23 @@
   }
 
   function onMouseMove(e: { movementX: number; movementY: number }) {
+
+
+
     if (moving) {
+      if (top + e.movementY < window.innerHeight * 0.05) {
+        return
+      }
+      if (top + e.movementY > window.innerHeight - (window.innerHeight * 0.12)) {
+        return
+      }
+      if (left + e.movementX < 0) {
+        return
+      }
+      if (left + e.movementX > window.innerWidth - (window.innerWidth * 0.12)) {
+        return
+      }
+
       left += e.movementX;
       top += e.movementY;
     }


### PR DESCRIPTION
This PR fixes too many apps going off screen because of the original flex column not wrapping to form a new column.

Also fixed the top bar being able to be dragged of the screen and not being able to move it again.